### PR TITLE
chore: add http header showing equivalent curl command

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -122,6 +122,8 @@ export const ApiRoutes: FastifyPluginCallback<Record<never, never>, Server, Type
       decodedResult = null;
     }
 
+    reply.header('x-curl-equiv', result.getCurlCmd());
+
     reply.send(decodedResult);
   });
   done();


### PR DESCRIPTION
Add an http header showing the equivalent curl command.

Example:
```
> curl -i 'http://localhost:3000/call-fn/SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR/arkadiko-swap-v2-1/get-pair-details?arg=SP3DX3H4FEYZJZ586MFBS25ZW3HZDMEW92260R2PR.Wrapped-Bitcoin&arg=SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.usda-token'
HTTP/1.1 200 OK
vary: Origin
access-control-allow-origin: *
etag: 36350db2ae4c161770a496cf48074a5664ac2ca3652ec37c539e11c488000a5a:ad993440da0a0b9e2fd5058ff12b09d86a695428d63ed19822e8064952fb692a
x-curl-equiv: curl -i -X POST 'https://stacks-node-api.mainnet.stacks.co/v2/contracts/call-read/SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR/arkadiko-swap-v2-1/get-pair-details' -H 'Content-Type: application/json' -d '{"sender":"STM9EQRAB3QAKF8NKTP15WJT7VHH4EWG3DJB4W29","arguments":["0x0616dbd1c48f77bf2f9506a3d79117fc1c7eda3b89100f577261707065642d426974636f696e","0x0616982f3ec112a5f5928a5c96a914bd733793b896a50a757364612d746f6b656e"]}'
content-type: application/json; charset=utf-8
content-length: 593
Date: Tue, 26 Jul 2022 19:49:06 GMT
```

Shows that in order to make the equivalent http request via curl, the following command is required:
```
curl -i \
-X POST 'https://stacks-node-api.mainnet.stacks.co/v2/contracts/call-read/SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR/arkadiko-swap-v2-1/get-pair-details' \
-H 'Content-Type: application/json' \
-d '{"sender":"STM9EQRAB3QAKF8NKTP15WJT7VHH4EWG3DJB4W29","arguments":["0x0616dbd1c48f77bf2f9506a3d79117fc1c7eda3b89100f577261707065642d426974636f696e","0x0616982f3ec112a5f5928a5c96a914bd733793b896a50a757364612d746f6b656e"]}'
```