### PR TITLE
feat: map entry lookup

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -72,13 +72,15 @@ export async function fetchJson<TOkResponse = unknown, TErrorResponse = unknown>
   try {
     respBody = JSON.parse(respText);
   } catch (error) {
-    const errorMsg = `${req.method} ${req.url} - error parsing JSON response ${resp.status}: ${respText}`;
-    throwFetchError(error as Error, errorMsg);
+    if (resp.ok) {
+      const errorMsg = `${req.method} ${req.url} - error parsing JSON response ${resp.status}: ${respText}`;
+      throwFetchError(error as Error, errorMsg);
+    }
   }
 
   if (resp.ok) {
     return { result: 'ok', status: resp.status, response: respBody as TOkResponse, getCurlCmd };
   } else {
-    return { result: 'error', status: resp.status, response: respBody as TErrorResponse, getCurlCmd };
+    return { result: 'error', status: resp.status, response: (respBody ?? respText) as TErrorResponse, getCurlCmd };
   }
 }


### PR DESCRIPTION
Endpoint wrapping `POST /v2/map_entry/:address/:contract/:map -- body: serialized key` 
as `GET /map-entry/:address/:contract/:map/:key`, with automatic Clarity value encoding and decoding.


E.g.: the equivalent of:
```shell
curl -i \
-X POST 'https://stacks-node-api.mainnet.stacks.co/v2/map_entry/SPNWZ5V2TPWGQGVDR6T7B6RQ4XMGZ4PXTEE0VQ0S/crypto-graffiti/nft-data?proof=0' \
-H 'Content-Type: application/json' \
-d '"0x010000000000000000000000000000002a"'
```
```json
{"data":"0x0a0c0000000307636c61696d656403086d657461646174610d00000035697066733a2f2f516d6334616d784d6e474a524d717034566a59675874414b63353953506a554a46586344455773487459347a53670570726963650100000000000000000000000002faf080"}
```
--vs--
```shell
curl -i 'localhost:3000/map-entry/SPNWZ5V2TPWGQGVDR6T7B6RQ4XMGZ4PXTEE0VQ0S/crypto-graffiti/nft-data/42'
```
```json
{"claimed":{"type":"bool","value":true},"metadata":{"type":"(string-ascii 53)","value":"ipfs://Qmc4amxMnGJRMqp4VjYgXtAKc59SPjUJFXcDEWsHtY4zSg"},"price":{"type":"uint","value":"50000000"}}
```

Example with `jq`
```shell
> curl 'localhost:3000/map-entry/SPNWZ5V2TPWGQGVDR6T7B6RQ4XMGZ4PXTEE0VQ0S/crypto-graffiti/nft-data/42' | jq .metadata.value 

"ipfs://Qmc4amxMnGJRMqp4VjYgXtAKc59SPjUJFXcDEWsHtY4zSg"
```