### PR TITLE
feat: endpoint to convert between stx and btc addresses and network version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@sinclair/typebox": "^0.24.20",
         "@stacks/transactions": "^4.3.3",
         "@types/node": "^18.0.3",
+        "c32check": "^1.1.3",
         "env-schema": "^5.0.0",
         "evt": "^1.11.2",
         "fastify": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@sinclair/typebox": "^0.24.20",
     "@stacks/transactions": "^4.3.3",
     "@types/node": "^18.0.3",
+    "c32check": "^1.1.3",
     "env-schema": "^5.0.0",
     "evt": "^1.11.2",
     "fastify": "^4.3.0",

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -8,8 +8,7 @@ import * as createError from '@fastify/error';
 import FastifySwagger from '@fastify/swagger';
 import { Type } from '@sinclair/typebox';
 import { ClarityAbi, ClarityAbiType, ClarityType, ClarityValue, cvToValue, deserializeCV, parseToCV, serializeCV } from '@stacks/transactions';
-import { fetchJson } from './util';
-
+import { fetchJson, getAddressInfo } from './util';
 
 export const STACKS_API_ENDPOINT = 'https://stacks-node-api.mainnet.stacks.co';
 
@@ -29,6 +28,26 @@ export const ApiRoutes: FastifyPluginCallback<Record<never, never>, Server, Type
 
   fastify.get('/', (request, reply) => {
     reply.send({ status: 'ok' });
+  });
+
+  fastify.get('/addr/:address', {
+    schema: {
+      params: Type.Object({
+        address: Type.String({
+          description: 'Specify either a Stacks or Bitcoin address',
+          examples: ['SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7', '1FzTxL9Mxnm2fdmnQEArfhzJHevwbvcH6d'],
+        }),
+      }),
+      querystring: Type.Object({
+        network: Type.Optional(Type.Union([Type.Literal('mainnet'), Type.Literal('testnet')], {
+          description: 'Specify if the address should be converted to mainnet or testnet',
+          examples: ['mainnet', 'testnet'],
+        }))
+      }),
+    }
+  }, (request, reply) => {
+    const addrInfo = getAddressInfo(request.params.address, request.query.network);
+    reply.type('application/json').send(addrInfo);
   });
 
   // POST /v2/map_entry/[Stacks Address]/[Contract Name]/[Map Name]

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,6 @@
 import { fetch as undiciFetch, Headers, Request, RequestInit, Response } from "undici";
 import * as createError from '@fastify/error';
+import * as c32check from 'c32check';
 
 const defaultFetchTimeout = 15_000; // 15 seconds
 
@@ -83,4 +84,56 @@ export async function fetchJson<TOkResponse = unknown, TErrorResponse = unknown>
   } else {
     return { result: 'error', status: resp.status, response: (respBody ?? respText) as TErrorResponse, getCurlCmd };
   }
+}
+
+/** Provide either a Stacks or Bitcoin address, and receive the Stacks address, Bitcoin address, and network version */
+export function getAddressInfo(addr: string, network: 'mainnet' | 'testnet' = 'mainnet') {
+  let b58addr: string;
+  if (addr.match(/^S[0123456789ABCDEFGHJKMNPQRSTVWXYZ]+$/)) {
+    b58addr = c32check.c32ToB58(addr);
+  } else if (addr.match(/[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]+/)) {
+    b58addr = addr;
+  } else {
+    throw new Error(`Unrecognized address ${addr}`);
+  }
+
+  let stxAddr = c32check.b58ToC32(b58addr);
+
+  let decodedStxAddr = c32check.c32addressDecode(stxAddr);
+
+  // Check if address needs coerced from one network version to another
+  if (network) {
+    if (network === 'mainnet' && decodedStxAddr[0] !== c32check.versions.mainnet.p2pkh && decodedStxAddr[0] !== c32check.versions.mainnet.p2sh) {
+      if (decodedStxAddr[0] === c32check.versions.testnet.p2pkh) {
+        decodedStxAddr[0] = c32check.versions.mainnet.p2pkh;
+      } else if (decodedStxAddr[0] === c32check.versions.testnet.p2sh) {
+        decodedStxAddr[0] = c32check.versions.testnet.p2pkh;
+      } else {
+        throw new Error(`Cannot convert address network type, unknown network version: ${decodedStxAddr[0]}`);
+      }
+    } else if (network === 'testnet' && decodedStxAddr[0] !== c32check.versions.testnet.p2pkh && decodedStxAddr[0] !== c32check.versions.testnet.p2sh) {
+      if (decodedStxAddr[0] === c32check.versions.mainnet.p2pkh) {
+        decodedStxAddr[0] = c32check.versions.testnet.p2pkh;
+      } else if (decodedStxAddr[0] === c32check.versions.mainnet.p2sh) {
+        decodedStxAddr[0] = c32check.versions.testnet.p2pkh;
+      } else {
+        throw new Error(`Cannot convert address network type, unknown network version: ${decodedStxAddr[0]}`);
+      }
+    }
+    stxAddr = c32check.c32address(decodedStxAddr[0], decodedStxAddr[1]);
+    b58addr = c32check.c32ToB58(stxAddr);
+  }
+
+  let networkName = 'other';
+  if (decodedStxAddr[0] === c32check.versions.testnet.p2pkh || decodedStxAddr[0] === c32check.versions.testnet.p2sh) {
+    networkName = 'testnet';
+  } else if (decodedStxAddr[0] === c32check.versions.mainnet.p2pkh || decodedStxAddr[0] === c32check.versions.mainnet.p2sh) {
+    networkName = 'mainnet';
+  }
+
+  return {
+    stacks: stxAddr,
+    bitcoin: b58addr,
+    network: networkName,
+  };
 }


### PR DESCRIPTION
Introduce endpoint `GET /addr/:address?network=<mainnet|testnet>`. Specify either a STX or BTC address (and optionally specify a network), and receive the encoded BTC and STX address back.

Examples:

`GET /addr/SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7`
```json
{"stacks":"SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7","bitcoin":"1FzTxL9Mxnm2fdmnQEArfhzJHevwbvcH6d","network":"mainnet"}
```
----
`GET /addr/SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7?network=testnet`
```json
{"stacks":"ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQYAC0RQ","bitcoin":"mvWRFPELmpCHSkFQ7o9EVdCd9eXeUTa9T8","network":"testnet"}
```
----
`GET /addr/1FzTxL9Mxnm2fdmnQEArfhzJHevwbvcH6d`
```json
{"stacks":"SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7","bitcoin":"1FzTxL9Mxnm2fdmnQEArfhzJHevwbvcH6d","network":"mainnet"}
```
----
`GET /addr/1FzTxL9Mxnm2fdmnQEArfhzJHevwbvcH6d?network=testnet`
```json
{"stacks":"ST2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKQYAC0RQ","bitcoin":"mvWRFPELmpCHSkFQ7o9EVdCd9eXeUTa9T8","network":"testnet"}
```

