### PR TITLE
add balances endpoint

### DIFF
--- a/src/routes/btc.ts
+++ b/src/routes/btc.ts
@@ -3,6 +3,10 @@ import { TypeBoxTypeProvider } from "@fastify/type-provider-typebox";
 import { FastifyPluginCallback } from "fastify";
 import { Type } from '@sinclair/typebox';
 import { getAddressInfo } from '../util';
+import { request } from 'undici';
+import { STACKS_API_ENDPOINT } from './node';
+
+const BLOCKCHAIN_API_ENDPOINT = 'https://blockchain.info/';
 
 export const BtcRoutes: FastifyPluginCallback<
   Record<never, never>,
@@ -27,5 +31,38 @@ export const BtcRoutes: FastifyPluginCallback<
   }, (request, reply) => {
     const addrInfo = getAddressInfo(request.params.address, request.query.network);
     reply.type('application/json').send(addrInfo);
+  });
+
+  fastify.get('/addr/:address/balances', {
+    schema: {
+      params: Type.Object({
+        address: Type.String({
+          description: 'Specify either a Stacks or Bitcoin address',
+          examples: ['SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7', '1FzTxL9Mxnm2fdmnQEArfhzJHevwbvcH6d'],
+        }),
+      })
+    }
+  }, async (req, reply) => {
+    const addrInfo = getAddressInfo(req.params.address, 'mainnet');
+
+    const stxBalanceReq = await request(
+      `${STACKS_API_ENDPOINT}/extended/v1/address/${addrInfo.stacks}/balances`, { method: 'GET' }
+    );
+    const stxBalance = await stxBalanceReq.body.json();
+    const btcBalanceReq = await request(
+      `${BLOCKCHAIN_API_ENDPOINT}/rawaddr/${addrInfo.bitcoin}?limit=0`
+    );
+    const btcBalance = await btcBalanceReq.body.json();
+
+    reply.type('application/json').send({
+      stacks: {
+        address: addrInfo.stacks,
+        balance: stxBalance.stx.balance
+      },
+      bitcoin: {
+        address: addrInfo.bitcoin,
+        balance: btcBalance.final_balance.toString()
+      }
+    });
   });
 }


### PR DESCRIPTION
creates the `/addr/:address/balances` endpoint

example: `/addr/SP3BK1NNSWN719Z6KDW05RBGVS940YCN6X84STYPR/balances`
```json
{
  "stacks": {
    "address": "SP3BK1NNSWN719Z6KDW05RBGVS940YCN6X84STYPR",
    "balance": "786809007"
  },
  "bitcoin": {
    "address": "1Lcpnd2DSVgNUZv5Kxoo15GKg9w4KrjDbz",
    "balance": "0"
  }
}
```