### PR TITLE
fix: format balance values to the correct decimals, use example address with balances

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@stacks/stacks-blockchain-api-types": "^4.1.0",
         "@stacks/transactions": "^4.3.3",
         "@types/node": "^18.0.3",
+        "bignumber.js": "^9.0.2",
         "c32check": "^1.1.3",
         "env-schema": "^5.0.0",
         "evt": "^1.11.2",
@@ -530,6 +531,14 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
+      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -2177,6 +2186,11 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "bignumber.js": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
+      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@stacks/stacks-blockchain-api-types": "^4.1.0",
     "@stacks/transactions": "^4.3.3",
     "@types/node": "^18.0.3",
+    "bignumber.js": "^9.0.2",
     "c32check": "^1.1.3",
     "env-schema": "^5.0.0",
     "evt": "^1.11.2",

--- a/src/api/routes/btc.ts
+++ b/src/api/routes/btc.ts
@@ -6,6 +6,7 @@ import { fetchJson, getAddressInfo } from '../util';
 import { request, fetch as undiciFetch } from 'undici';
 import * as stacksApiClient from '@stacks/blockchain-api-client';
 import * as stackApiTypes from '@stacks/stacks-blockchain-api-types';
+import BigNumber from 'bignumber.js';
 import { BLOCKCHAIN_EXPLORER_ENDPOINT, BLOCKCHAIN_INFO_API_ENDPOINT, STACKS_API_ENDPOINT, STACKS_EXPLORER_ENDPOINT } from '../../consts';
 
 
@@ -39,7 +40,7 @@ export const BtcRoutes: FastifyPluginCallback<
       params: Type.Object({
         address: Type.String({
           description: 'Specify either a Stacks or Bitcoin address',
-          examples: ['SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7', '1FzTxL9Mxnm2fdmnQEArfhzJHevwbvcH6d'],
+          examples: ['SPRSDSRT18DS9R8Y2W13JTKF89NFHEGDWQPB78RE', '15XCtJkEDxE1nhFawvPY4QEkEyNywxNSfL'],
         }),
       })
     }
@@ -50,19 +51,21 @@ export const BtcRoutes: FastifyPluginCallback<
       `${STACKS_API_ENDPOINT}/extended/v1/address/${addrInfo.stacks}/balances`, { method: 'GET' }
     );
     const stxBalance = await stxBalanceReq.body.json();
+    const stxBalanceFormatted = new BigNumber(stxBalance.stx.balance).shiftedBy(-6).toFixed(6);
     const btcBalanceReq = await request(
       `${BLOCKCHAIN_INFO_API_ENDPOINT}/rawaddr/${addrInfo.bitcoin}?limit=0`
     );
     const btcBalance = await btcBalanceReq.body.json();
+    const btcBalanceFormatted = new BigNumber(btcBalance.final_balance).shiftedBy(-8).toFixed(8);
 
     reply.type('application/json').send(JSON.stringify({
       stacks: {
         address: addrInfo.stacks,
-        balance: stxBalance.stx.balance
+        balance: stxBalanceFormatted
       },
       bitcoin: {
         address: addrInfo.bitcoin,
-        balance: btcBalance.final_balance.toString()
+        balance: btcBalanceFormatted
       }
     }, null, 2));
   });


### PR DESCRIPTION
Format STX and BTC balance values with decimal points. Update example address to one with balances. Example:

<img width="708" alt="image" src="https://user-images.githubusercontent.com/1447546/181302496-dbbbec2f-f616-4dd0-951f-17c9f5d955f6.png">
